### PR TITLE
Error on admin commands

### DIFF
--- a/daemon_shop.js
+++ b/daemon_shop.js
@@ -661,7 +661,7 @@ function handleAccepted(offer, oldState) {
 
 
 client.on("friendMessage", function(steamID, message) {
-    if (steamID.getSteamID64() == admin) {
+    if (steamID.getSteamID64() == config.admin) {
 
         /*
         if (message == "!trades") {


### PR DESCRIPTION
664      if (steamID.getSteamID64() == admin) 👎 

664 if (steamID.getSteamID64() == config.admin) 👍 
Now, this error on admin indefined is corrected.